### PR TITLE
G4E-4743 - Add new panel to the floating toolbar

### DIFF
--- a/app-config.json
+++ b/app-config.json
@@ -41,7 +41,7 @@
     "allowMultiple": false,
     "ignoreSavedLayout": false,
     "customProperties": {
-        "hideFeedbackButton": false,
-        "hideProfileButton": true
+        "hideFeedbackButton": true,
+        "hideProfileButton": false
     }
 }

--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
                     Profile
                     <span class="icon-arrow-up-down close-drawer"></span>
                 </h5>
-                <table class="mb-auto ml-auto mr-auto mt-5">
+                <table class="mb-auto">
                     <tr>
                         <td class="text-right">User</td>
                         <td class="pl-3"><span class="profile-sid"></span></td>

--- a/js/profile.js
+++ b/js/profile.js
@@ -31,8 +31,19 @@ async function populateProfileData() {
     } else {
         q('.profile-sid').innerText = SID;
     }
-    q('.profile-reg').innerText = reg;
-    q('.profile-env').innerText = env;
+    if (reg.length > 15) {
+        const trimmedReg = reg.substring(0, 15) + "...";
+        q('.profile-reg').innerText = trimmedReg;
+    } else {
+        q('.profile-reg').innerText = reg;
+    }
+    if (env.length > 15) {
+        const trimmedEnv = env.substring(0, 15) + "...";
+        q('.profile-env').innerText = trimmedEnv;
+    } else {
+        q('.profile-env').innerText = env;
+    }
+    
     q('.profile-version').innerText = GDVer;
     q('.profile-gwport').innerText = port;
     q('.server-info').innerHTML = serverInfo;

--- a/scss/app.css
+++ b/scss/app.css
@@ -1117,3 +1117,6 @@ html .h .close-drawer {
   bottom: 0;
 }
 
+.profile-sid {
+  word-wrap: break-all;
+}

--- a/scss/app.css
+++ b/scss/app.css
@@ -1116,7 +1116,3 @@ html .h .close-drawer {
   top: 0;
   bottom: 0;
 }
-
-.profile-sid {
-  word-wrap: break-all;
-}


### PR DESCRIPTION
The purpose of this PR is to fix styling of the 'table' with data in the 'Profile' tab when the floating toolbar is used vertically. An issue was discovered where the buttons were getting cut-off and the table was not displayed correctly. 
Additionally, new checks for lengths for REG/ENV are placed after QA comments, now they are being cropped if they exceed a higher number of characters to preserve the styling and to better display them in the panel. 