### PR TITLE
Fav apps section - display app's name when app's title is not provided

### DIFF
--- a/js/applications.js
+++ b/js/applications.js
@@ -184,11 +184,14 @@ function favoriteApplicationHTMLTemplate(app) {
   if (!app) {
     return '';
   }
+
+  const displayName = typeof app.title === 'string' ? app.title : app.name;
+
   return `
   <li class="nav-item ${app.instances.length > 0 ? 'app-active' : ''}" app-name="${app.name}">
-    <a class="nav-link" href="#" draggable="false" title="${app.title}">
+    <a class="nav-link" href="#" draggable="false" title="${displayName}">
       ${getAppIcon(app)}
-      <span class="text-animation">${app.title}</span>
+      <span class="text-animation">${displayName}</span>
     </a>
   </li>
   `;


### PR DESCRIPTION
As per the [application schema](https://docs.glue42.com/assets/configuration/application.json), application title is not a required property. If a title is not provided, then favorite apps section displays "undefined".

![fav-apps](https://user-images.githubusercontent.com/10837541/163567318-78cf7e4a-5fdd-4a30-addb-8d822210be88.PNG)

